### PR TITLE
Style cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,93 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+doc/_build/
+doc/source/generated
+doc/source/odl_interface
+doc/source/odl*.rst
+
+# PyBuilder
+target/
+
+# Backups from futurize/pasteurize
+*.py.bak
+
+# Visual studio
+*.sdf
+*.sln
+*.suo
+*.pyproj
+*.pyproj.user
+*.pyperf
+*.psess
+
+# vim viles
+*.swp
+*.swo
+*~
+
+# Spyder project files
+.spyproject/
+.spyderproject
+.spyderworkspace
+.spyproject/
+
+# PyCharm project files
+.idea
+
+# IPython / Jupyter notebook files
+*.ipynb
+.ipynb_checkpoints
+
+# Documentation build files

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib64/
 parts/
 sdist/
 var/
+data/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/CGLS_reco_skullCT.py
+++ b/CGLS_reco_skullCT.py
@@ -4,45 +4,49 @@ CGLS reconstruction example for simulated Skull CT data
 import odl
 import numpy as np
 import os
-from adutils import *
+import adutils
 
 # Discretization
-discr_reco_space = get_discretization()
+reco_space = adutils.get_discretization()
 
 # Forward operator (in the form of a broadcast operator)
-A = get_ray_trafo()
+A = adutils.get_ray_trafo(reco_space)
 
 # Data
-rhs = get_data(A)
+rhs = adutils.get_data(A)
 
 # Reconstruct
-callbackShowReco = (odl.solvers.CallbackPrintIteration() & 
-            odl.solvers.CallbackShow(coords=[None, 0, None]) & 
-            odl.solvers.CallbackShow(coords=[0, None, None]) & 
-            odl.solvers.CallbackShow(coords=[None, None, 60]))
+callbackShowReco = (odl.solvers.CallbackPrintIteration() &
+                    odl.solvers.CallbackShow(coords=[None, 0, None]) &
+                    odl.solvers.CallbackShow(coords=[0, None, None]) &
+                    odl.solvers.CallbackShow(coords=[None, None, 60]))
 
 callbackPrintIter = odl.solvers.CallbackPrintIteration()
 
 # Start with empty x
-x = discr_reco_space.zero()
+x = reco_space.zero()
 
-# Run such that every 5th iteration is saved (saveCont == 1) or only the last one (saveCont == 0)
-saveCont = 0
+# Run such that every 5th iteration is saved (saveCont == True)
+# or only the last one (saveCont == False)
+saveCont = False
 
-if saveCont == 0:
+if not saveCont:
     niter = 5
     odl.solvers.conjugate_gradient_normal(A, x, rhs, niter=niter, callback = callbackPrintIter)
-    saveName = '/lcrnas/data/Simulated/120kV/reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_CGLS_' + str(niter) + 'iterations.npy'
-    np.save(saveName,np.asarray(x))
+    if False:
+        saveName = '/lcrnas/data/Simulated/120kV/reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_CGLS_' + str(niter) + 'iterations.npy'
+        np.save(saveName,np.asarray(x))
 
-else:    
+else:
     startiter = 5
     enditer = 101
     stepiter = 5
-    niter = [int(i) for i in np.arange(startiter,enditer,stepiter)]
-    saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_CGLS_'
-    savePath = os.path.join('/lcrnas/data/Simulated/120kV/','reco',saveNameStart)
+    niter = [int(i) for i in np.arange(startiter, enditer, stepiter)]
     for iterations in niter:
-        odl.solvers.conjugate_gradient_normal(A, x, rhs, niter = stepiter, callback = callbackPrintIter)
-        saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
-        np.save(saveName,np.asarray(x))
+        odl.solvers.conjugate_gradient_normal(A, x, rhs, niter=stepiter,
+                                              callback=callbackPrintIter)
+        if False:
+            saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_CGLS_'
+            savePath = os.path.join('/lcrnas/data/Simulated/120kV/','reco',saveNameStart)
+            saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
+            np.save(saveName, np.asarray(x))

--- a/FBP_reco_skullCT.py
+++ b/FBP_reco_skullCT.py
@@ -9,16 +9,21 @@ import adutils
 reco_space = adutils.get_discretization()
 
 # Forward operator (in the form of a broadcast operator)
-A = adutils.get_ray_trafo(reco_space)
+A = adutils.get_ray_trafo(reco_space, use_subset=True)
 
 # Define fbp
 fbp = adutils.get_fbp(A)
 
 # Data
-rhs = adutils.get_data(A)
+rhs = adutils.get_data(A, use_subset=True)
 
 # Reconstruct
 x = fbp(rhs)
+
+# Show result
+x.show(coords=[None, 0, None])
+x.show(coords=[0, None, None])
+x.show(coords=[None, None, 90])
 
 # Save
 if False:

--- a/FBP_reco_skullCT.py
+++ b/FBP_reco_skullCT.py
@@ -2,25 +2,25 @@
 FBP reconstruction example for simulated Skull CT data
 """
 
-import odl
 import numpy as np
-from adutils import *
+import adutils
 
 # Discretization
-discr_reco_space = get_discretization()
+reco_space = adutils.get_discretization()
 
 # Forward operator (in the form of a broadcast operator)
-A = get_ray_trafo()
+A = adutils.get_ray_trafo(reco_space)
 
 # Define fbp
-fbp = get_fbp(A)
+fbp = adutils.get_fbp(A)
 
 # Data
-rhs = get_data(A)
+rhs = adutils.get_data(A)
 
 # Reconstruct
 x = fbp(rhs)
 
 # Save
-saveName = '/lcrnas/data/Simulated/120kV/reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_FBP.npy'
-np.save(saveName,np.asarray(x))
+if False:
+    saveName = '/lcrnas/data/Simulated/120kV/reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_FBP.npy'
+    np.save(saveName, np.asarray(x))

--- a/Landweber_reco_skullCT.py
+++ b/Landweber_reco_skullCT.py
@@ -4,40 +4,41 @@ Landweber reconstruction example for simulated Skull CT data
 import odl
 import numpy as np
 import os
-from adutils import *
+import adutils
 
 # Discretization
-discr_reco_space = get_discretization()
+reco_space = adutils.get_discretization()
 
 # Forward operator (in the form of a broadcast operator)
-A = get_ray_trafo()
+A = adutils.get_ray_trafo(reco_space)
 
 # Data
-rhs = get_data(A)
+rhs = adutils.get_data(A)
 
 # Reconstruct
-callbackShowReco = (odl.solvers.CallbackPrintIteration() & 
-            odl.solvers.CallbackShow(coords=[None, 0, None]) & 
-            odl.solvers.CallbackShow(coords=[0, None, None]) & 
+callbackShowReco = (odl.solvers.CallbackPrintIteration() &
+            odl.solvers.CallbackShow(coords=[None, 0, None]) &
+            odl.solvers.CallbackShow(coords=[0, None, None]) &
             odl.solvers.CallbackShow(coords=[None, None, 60]))
 
 callbackPrintIter = odl.solvers.CallbackPrintIteration()
 
 # Start with empty x
-x = discr_reco_space.zero()
+x = reco_space.zero()
 
-# Run such that every 5th iteration is saved (saveCont == 1) or only the last one (saveCont == 0)
+# Run such that every 5th iteration is saved (saveCont == True)
+# or only the last one (saveCont == False)
 saveCont = 0
 
 omega = 0.005
 
-if saveCont == 0:
+if not saveCont:
     niter = 5
     odl.solvers.landweber(A, x, rhs, niter=niter, omega=omega, callback = callbackPrintIter)
-    saveName = '/lcrnas/data/Simulated/120kV/reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_Landweber_' + str(niter) + 'iterations.npy'
-    np.save(saveName,np.asarray(x))
-
-else:    
+    if False:
+        saveName = '/lcrnas/data/Simulated/120kV/reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_Landweber_' + str(niter) + 'iterations.npy'
+        np.save(saveName,np.asarray(x))
+else:
     startiter = 5
     enditer = 101
     stepiter = 5
@@ -45,6 +46,8 @@ else:
     saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_Landweber_'
     savePath = os.path.join('/lcrnas/data/Simulated/120kV/','reco',saveNameStart)
     for iterations in niter:
-        odl.solvers.landweber(A, x, rhs, niter=stepiter, omega=omega, callback = callbackPrintIter)
-        saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
-        np.save(saveName,np.asarray(x))
+        odl.solvers.landweber(A, x, rhs, niter=stepiter, omega=omega,
+                              callback=callbackPrintIter)
+        if False:
+            saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
+            np.save(saveName,np.asarray(x))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # ad-skull-reconstruction
 Repository for reconstruction of simulated skull CT data for AD project with files for reconstruction simulated skull CT data (KTH/SSF AD project)
 
+Usage
+#####
+In order to use this repo, you first need to copy the data to your local machine. This can be done by:
+```
+$ python -c "import adutils; adutils.load_data_from_nas('Z:\\')"
+```
+where `'Z:\\'` should be replaced with your local path to the data drive of the NAS. This takes quite some time (~10 minutes) to run at first, but makes subsequent reconstructions much faster. Note that it uses ~6GB of disk space in a subfolder to this project.
+
+Files to read and reconstruct the data is given in this repository (the easiest example is given by a FBP reconstruction in ```FBP_reco_skullCT.py```). Most of the data handling is however hidden in ```adutils.py```. To make use of these, simply run the following in your script
+```
+import adutils
+```  
+
+Raw data
+########
+
 All simulated data is available on the lcrnas-repo. For high dose (150 mGy) skullCT (following settings used at KI Geriatrics), data can be found in:
 ```
   /lcrnas/data/Simulated/120kV
@@ -13,10 +29,7 @@ with corresponding geometry pickled in
 ```
   HelicalSkullCT_70100644Phantom_no_bed_Turn_{0,1,2,3,...,22}.geometry.p
 ```  
-Files to read and reconstruct these are given in this repository (the easiest example is given by a FBP reconstruction in ```FBP_reco_skullCT.py```). Most of the data handling is however hidden in ```adutils.py```. To make use of these, simply run the following in your script
-```
-  from adutils import *
-```  
 Note: Data with lower dosage is available upon request. All simulated data is given in ```/lcrnas/data/Simulated/120kV/raw/```. **DO NOT change the data in this repository**. If unsure, ask. 
+
 
 

--- a/Simplified_DoseCalculation_skullCT.py
+++ b/Simplified_DoseCalculation_skullCT.py
@@ -14,7 +14,7 @@ def get_spectrum(n):
     dat = np.loadtxt(path+'spectrumGeriatrics.txt')
     energies = dat[:, 0] / 1000.0
     spectrum = dat[:, 1]
-    
+
     indices = np.linspace(0, energies.size - 1, n, dtype=int)
     energies = energies[indices]
     spectrum = spectrum[indices]
@@ -23,11 +23,11 @@ def get_spectrum(n):
 
 def getPhantom(phantomName):
 
-    #nifit data 
+    #nifit data
     path = '/lcrnas/data/Simulated/code/AD_GPUMCI/phantoms/'
     nii = nib.load(path+phantomName)
     phantomdata = nii.get_data()
-                          
+
     densities = np.zeros_like(phantomdata, dtype=float)
     densities[phantomdata == 1] = 1.015   # fat
     densities[phantomdata == 2] = 1.8   # bone
@@ -42,9 +42,9 @@ def getPhantom(phantomName):
     mat[phantomdata == 2] = 2     # bone
     mat[phantomdata == 4] = 4     # white matter
     mat[phantomdata == 3] = 3     # grey matter
-    
+
     return densities, mat
-    
+
 energies, spectrum = get_spectrum(10)
 photons_per_pixel_one_run = 1000
 simNum = 120
@@ -54,17 +54,17 @@ numberOfPixels = 500*20
 numberOfTurns = 23
 numberOfProjections = 4000
 
-energyInPerProjection = photons_per_pixel* numberOfPixels * np.sum(energies*spectrum) 
+energyInPerProjection = photons_per_pixel* numberOfPixels * np.sum(energies*spectrum)
 
 energyHeadPerProjection = []
 for turn in range(numberOfTurns):
     print(turn)
-    file = ('/lcrnas/data//Simulated/120kV/raw/' +  
-           'helical_proj_70100644Phantom_labelled_no_bed_' + str(simNum) + 
-           '_Simulations_Turn_num_' + str(turn) + '.npy')
-    proj = np.load(file)
+    file_name = ('/lcrnas/data//Simulated/120kV/raw/' +
+                 'helical_proj_70100644Phantom_labelled_no_bed_' + str(simNum) +
+                 '_Simulations_Turn_num_' + str(turn) + '.npy')
+    proj = np.load(file_name)
     for projection in range(numberOfProjections):
-        energyHeadPerProjection.append(energyInPerProjection - 
+        energyHeadPerProjection.append(energyInPerProjection -
                                        np.sum(proj[projection,...]))
 
 MeV2J = 1.6021773e-13

--- a/TV_parameter_search_skullCT.py
+++ b/TV_parameter_search_skullCT.py
@@ -4,29 +4,29 @@ TV reconstruction example for simulated Skull CT data - lambda parameter search
 import odl
 import numpy as np
 import os
-from adutils import *
+import adutils
 
 # Discretization
-discr_reco_space = get_discretization()
+reco_space = adutils.get_discretization()
 
 # Forward operator (in the form of a broadcast operator)
-A = get_ray_trafo()
+A = adutils.get_ray_trafo(reco_space)
 
 # Define fbp in order to use it as initial guess for TV reco
-fbp = get_fbp(A)
+fbp = adutils.get_fbp(A)
 
 # Data
-rhs = get_data(A)
+rhs = adutils.get_data(A)
 
 # Gradient operator
-gradient = odl.Gradient(discr_reco_space, method='forward')
+gradient = odl.Gradient(reco_space, method='forward')
 
 # Column vector of operators
 op = odl.BroadcastOperator(A, gradient)
 
 Anorm = odl.power_method_opnorm(A[1], maxiter=2)
-Dnorm = odl.power_method_opnorm(gradient, 
-                                xstart=odl.phantom.white_noise(gradient.domain), 
+Dnorm = odl.power_method_opnorm(gradient,
+                                xstart=odl.phantom.white_noise(gradient.domain),
                                 maxiter=10)
 
 # Estimated operator norm, add 10 percent
@@ -39,7 +39,7 @@ lambs = (0.01, 0.005, 0.003, 0.001, 0.0008, 0.0005, 0.0003, 0.0001)
 # Use FBP as initial guess
 x_init = fbp(rhs)
 
-for lamb in lambs:      
+for lamb in lambs:
     # l2-squared data matching
     l2_norm = odl.solvers.L2NormSquared(A.range).translated(rhs)
 
@@ -48,51 +48,53 @@ for lamb in lambs:
 
     # Combine functionals
     f = odl.solvers.SeparableSum(l2_norm, l1_norm)
-    
+
     # Set g functional to zero
     g = odl.solvers.ZeroFunctional(op.domain)
-    
+
     # Accelerataion parameter
     gamma=0.4
-    
+
     # Step size for the proximal operator for the primal variable x
-    tau = 1.0 / op_norm 
-    	
+    tau = 1.0 / op_norm
+
     # Step size for the proximal operator for the dual variable y
     sigma = 1.0 / op_norm #1.0 / (op_norm ** 2 * tau)
 
     # Reconstruct
     callbackShowReco = (odl.solvers.CallbackPrintIteration() & #Print iterations
                 odl.solvers.CallbackShow(coords=[None, 0, None]) & #Show parital reconstructions
-                odl.solvers.CallbackShow(coords=[0, None, None]) & 
+                odl.solvers.CallbackShow(coords=[0, None, None]) &
                 odl.solvers.CallbackShow(coords=[None, None, 60]))
-    	
+
     callbackPrintIter = odl.solvers.CallbackPrintIteration()
-             
+
     # Use the FBP as initial guess
     x = x_init
-    
+
     # Run such that every 5th iteration is saved (saveCont == 1) or only the last one (saveCont == 0)
     saveCont = 1
     savePath = '/lcrnas/data/Simulated/120kV/'
-    
+
     if saveCont == 0:
         niter = 100
-        odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma, 
+        odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma,
                                           niter = niter, gamma=gamma, callback=callbackPrintIter)
-        saveName = os.path.join(savePath,'reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_lambda{}_'.format(lamb) + 
-                                          str(niter) + 'iterations.npy')
-        np.save(saveName,np.asarray(x))
-        
-    else:    
+        if False:
+            saveName = os.path.join(savePath,'reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_lambda{}_'.format(lamb) +
+                                              str(niter) + 'iterations.npy')
+            np.save(saveName,np.asarray(x))
+
+    else:
         startiter = 5
         enditer = 101
         stepiter = 5
         niter = [int(i) for i in np.arange(startiter,enditer,stepiter)]
-        saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_lambda{}_'.format(lamb)
-        savePath = os.path.join(savePath,'reco',saveNameStart)
         for iterations in niter:
-            odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma, 
+            odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma,
                                               niter = stepiter, gamma=gamma, callback=callbackPrintIter)
-            saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
-            np.save(saveName,np.asarray(x))
+            if False:
+                saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_lambda{}_'.format(lamb)
+                savePath = os.path.join(savePath,'reco',saveNameStart)
+                saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
+                np.save(saveName,np.asarray(x))

--- a/TV_reco_skullCT.py
+++ b/TV_reco_skullCT.py
@@ -5,29 +5,29 @@ TV reconstruction example for simulated Skull CT data
 import odl
 import numpy as np
 import os
-from adutils import *
+import adutils
 
 # Discretization
-discr_reco_space = get_discretization()
+reco_space = adutils.get_discretization()
 
 # Forward operator (in the form of a broadcast operator)
-A = get_ray_trafo()
+A = adutils.get_ray_trafo(reco_space)
 
 # Define fbp in order to use it as initial guess for TV reco
-fbp = get_fbp(A)
+fbp = adutils.get_fbp(A)
 
 # Data
-rhs = get_data(A)
+rhs = adutils.get_data(A)
 
 # Gradient operator
-gradient = odl.Gradient(discr_reco_space, method='forward')
+gradient = odl.Gradient(reco_space, method='forward')
 
 # Column vector of operators
 op = odl.BroadcastOperator(A, gradient)
 
 Anorm = odl.power_method_opnorm(A[1], maxiter=2)
-Dnorm = odl.power_method_opnorm(gradient, 
-                                xstart=odl.phantom.white_noise(gradient.domain), 
+Dnorm = odl.power_method_opnorm(gradient,
+                                xstart=odl.phantom.white_noise(gradient.domain),
                                 maxiter=10)
 
 # Estimated operator norm, add 10 percent
@@ -35,7 +35,7 @@ op_norm = 1.1 * np.sqrt(len(A.operators)*(Anorm**2) + Dnorm**2)
 
 print('Norm of the product space operator: {}'.format(op_norm))
 
-lamb = 0.005 #l2NormGrad/l1NormGrad = 0.01
+lamb = 0.005  # l2NormGrad/l1NormGrad = 0.01
 
 # l2-squared data matching
 l2_norm = odl.solvers.L2NormSquared(A.range).translated(rhs)
@@ -50,46 +50,47 @@ f = odl.solvers.SeparableSum(l2_norm, l1_norm)
 g = odl.solvers.ZeroFunctional(op.domain)
 
 # Accelerataion parameter
-gamma=0.4
+gamma = 0.4
 
 # Step size for the proximal operator for the primal variable x
-tau = 1.0 / op_norm 
-	
+tau = 1.0 / op_norm
+
 # Step size for the proximal operator for the dual variable y
-sigma = 1.0 / op_norm #1.0 / (op_norm ** 2 * tau)
+sigma = 1.0 / op_norm  # 1.0 / (op_norm ** 2 * tau)
 
 # Reconstruct
-callbackShowReco = (odl.solvers.CallbackPrintIteration() & #Print iterations
-            odl.solvers.CallbackShow(coords=[None, 0, None]) & #Show parital reconstructions
-            odl.solvers.CallbackShow(coords=[0, None, None]) & 
-            odl.solvers.CallbackShow(coords=[None, None, 60]))
-	
+callbackShowReco = (odl.solvers.CallbackPrintIteration() &  # Print iterations
+                    odl.solvers.CallbackShow(coords=[None, 0, None]) &  # Show parital reconstructions
+                    odl.solvers.CallbackShow(coords=[0, None, None]) &
+                    odl.solvers.CallbackShow(coords=[None, None, 60]))
+
 callbackPrintIter = odl.solvers.CallbackPrintIteration()
 
 # Use FBP as initial guess
 x = fbp(rhs)
-    
+
 # Run such that every 5th iteration is saved (saveCont == 1) or only the last one (saveCont == 0)
 saveCont = 0
 savePath = '/lcrnas/data/Simulated/120kV/'
 if saveCont == 0:
     niter = 100
-    odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma, 
+    odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma,
                                       niter = niter, gamma=gamma, callback=callbackPrintIter)
-    saveName = os.path.join(savePath,'reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_' + 
-                                      str(niter) + 'iterations.npy')
-    np.save(saveName,np.asarray(x))
-    
-else:    
+    if False:
+        saveName = os.path.join(savePath,'reco/Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_' +
+                                          str(niter) + 'iterations.npy')
+        np.save(saveName,np.asarray(x))
+
+else:
     startiter = 5
     enditer = 101
     stepiter = 5
-    niter = [int(i) for i in np.arange(startiter,enditer,stepiter)]
-    saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_'
-    savePath = os.path.join(savePath,'reco',saveNameStart)
+    niter = [int(i) for i in np.arange(startiter, enditer, stepiter)]
     for iterations in niter:
-        odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma, 
+        odl.solvers.chambolle_pock_solver(x, f, g, op, tau=tau, sigma = sigma,
                                           niter = stepiter, gamma=gamma, callback=callbackPrintIter)
-        saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
-        np.save(saveName,np.asarray(x))
-                
+        if False:
+            saveNameStart = 'Reco_HelicalSkullCT_70100644Phantom_no_bed_Dose150mGy_TV_'
+            savePath = os.path.join(savePath,'reco',saveNameStart)
+            saveName = (savePath + '{}iterations'.format(iterations) + '.npy')
+            np.save(saveName,np.asarray(x))

--- a/adutils.py
+++ b/adutils.py
@@ -1,87 +1,98 @@
 """
-    Utility function to read simulated skull CT data and get correct geomtry for reconstruction, as well as an fbp defintion (from odl)
+Utility function to read simulated skull CT data and get correct geomtry for reconstruction, as well as an fbp defintion (from odl)
 """
 import odl
 import numpy as np
 import os
 import nibabel as nib
-import pickle 
+import pickle
 
-global filePath, fileStart, nTurns
+
 filePath = '/lcrnas/data/Simulated/120kV/'
 fileStart = 'HelicalSkullCT_70100644Phantom_no_bed_'
 nTurns = 23
 
+
 def getPhantomSize(phantomName):
-    #nifit data 
+    # nifit data
     path = '/lcrnas/data/Simulated/code/AD_GPUMCI/phantoms/'
     nii = nib.load(path+phantomName)
     phantomdata = nii.get_data()
     phantomSize = np.shape(phantomdata)
     return phantomSize
-        
+
+
 def get_discretization():
     phantomName = '70100644Phantom_labelled_no_bed.nii'
-    
+
     # Set geometry for discretization
-    pitch_mm = 6.6
     volumeSize = np.array([230.0, 230.0, 141.0546875])
-    volumeOrigin = np.array([-115.0, -115.0, 0]) 
-    
+    volumeOrigin = np.array([-115.0, -115.0, 0])
+
     # Discretization parameters
     phantomSize = getPhantomSize(phantomName)
-    nVoxels, nPixels = np.array(phantomSize), [500, 20]
-    
-    # Discrete reconstruction space
-    discr_reco_space = odl.uniform_discr(volumeOrigin,volumeOrigin + volumeSize,
-                                         nVoxels, dtype='float32')
-    return discr_reco_space
+    nVoxels = np.array(phantomSize)
 
-def get_ray_trafo():  
+    # Discrete reconstruction space
+    reco_space = odl.uniform_discr(volumeOrigin,
+                                   volumeOrigin + volumeSize,
+                                   nVoxels, dtype='float32')
+    return reco_space
+
+
+def get_ray_trafo(reco_space, use_subset=False):
     # Geometry and forward projector
-    turns = range(nTurns)
-    turns = range(13,16)
+    if use_subset:
+        turns = range(13, 16)
+    else:
+        turns = range(nTurns)
+
     Aops = []
-    discr_reco_space = get_discretization()
+
     for turn in turns:
-        print("Loading geometry for turn number %i out of %i" % (turn+1,nTurns))
-        geomFile = os.path.join(filePath,(fileStart + 'Turn_' + str(turn) + '.geometry.p'))
+        print("Loading geometry for turn number {} out of {}".format(turn + 1, nTurns))
+        geomFile = os.path.join(filePath, (fileStart + 'Turn_' + str(turn) + '.geometry.p'))
         # Load pickled geometry (small workaround of incompatibility between Python2/Python3 in pickle)
         with open(geomFile, 'rb') as f:
             geom = pickle.load(f, encoding='latin1')
         # X-ray transform
-        Aops += [odl.tomo.RayTransform(discr_reco_space, geom, impl='astra_cuda')]
-    
+        Aops.append(odl.tomo.RayTransform(reco_space, geom, impl='astra_cuda'))
+
     A = odl.BroadcastOperator(*Aops)
-    
+
     return A
 
+
 def get_fbp(A):
-    fbp = odl.ReductionOperator(*[(odl.tomo.fbp_op(Ai, 
+    fbp = odl.ReductionOperator(*[(odl.tomo.fbp_op(Ai,
                                               padding=True,
-                                              filter_type='Hamming', #Hann 
+                                              filter_type='Hamming', #Hann
                                               frequency_scaling=0.8) *
                                odl.tomo.tam_danielson_window(Ai))
                               for Ai in A])
     return fbp
-    
-def get_data(A):
+
+
+def get_data(A, use_subset=False):
     # Data
-    turns = range(nTurns)
-    turns = range(13,16)
+    if use_subset:
+        turns = range(13, 16)
+    else:
+        turns = range(nTurns)
+
     imagesTurn = []
-    for turn in turns:   
-        print("Loading data for turn number %i out of %i" % (turn+1,nTurns))
-        dataFile = os.path.join(filePath,(fileStart + 'Dose150mGy_Turn_' + str(turn) + '.data.npy'))
+    for turn in turns:
+        print("Loading data for turn number {} out of {}".format(turn + 1, nTurns))
+        dataFile = os.path.join(filePath, (fileStart + 'Dose150mGy_Turn_' + str(turn) + '.data.npy'))
         projections = np.load(dataFile).astype('float32')
-        imagesTurn += [-np.log(projections / 7910)] 
-    
+        imagesTurn.append(-np.log(projections / 7910))
+
     rhs = A.range.element(imagesTurn)
-    
+
     return rhs
-        
-    
-    
-    
-    
-    
+
+
+
+
+
+

--- a/adutils.py
+++ b/adutils.py
@@ -1,37 +1,50 @@
 """
-Utility function to read simulated skull CT data and get correct geomtry for reconstruction, as well as an fbp defintion (from odl)
+Utility function to read simulated skull CT data.
+
+Also fetches correct geomtry for reconstruction and provides a fbp defintion.
 """
 import odl
 import numpy as np
 import os
-import nibabel as nib
+import sys
+import glob
+import shutil
 import pickle
 
-
-filePath = '/lcrnas/data/Simulated/120kV/'
+dir_path = os.path.dirname(os.path.realpath(__file__))
+data_path = os.path.join(dir_path, 'data', 'Simulated', '120kV')
 fileStart = 'HelicalSkullCT_70100644Phantom_no_bed_'
 nTurns = 23
+PY3 = (sys.version_info > (3, 0))
 
 
-def getPhantomSize(phantomName):
-    # nifit data
-    path = '/lcrnas/data/Simulated/code/AD_GPUMCI/phantoms/'
-    nii = nib.load(path+phantomName)
-    phantomdata = nii.get_data()
-    phantomSize = np.shape(phantomdata)
-    return phantomSize
+def load_data_from_nas(nas_path):
+    """Load all the needed data from the nas onto your local machine
+
+    This makes loading files much faster.
+
+    Usage on windows where nas is bound to "Z:\"
+
+    python -c "import adutils; adutils.load_data_from_nas('Z:\\')"
+    """
+    if not os.path.exists(data_path):
+        os.makedirs(data_path)
+
+    nas_data_path = os.path.join(nas_path, 'Simulated', '120kV')
+    if not os.path.exists(nas_path):
+        raise IOError('Cannot find NAS data at {}'.format(nas_data_path))
+
+    for filename in glob.glob(os.path.join(nas_data_path, '*.*')):
+        shutil.copy(filename, data_path)
 
 
 def get_discretization():
-    phantomName = '70100644Phantom_labelled_no_bed.nii'
-
     # Set geometry for discretization
     volumeSize = np.array([230.0, 230.0, 141.0546875])
     volumeOrigin = np.array([-115.0, -115.0, 0])
 
     # Discretization parameters
-    phantomSize = getPhantomSize(phantomName)
-    nVoxels = np.array(phantomSize)
+    nVoxels = np.array([512, 512, 314])
 
     # Discrete reconstruction space
     reco_space = odl.uniform_discr(volumeOrigin,
@@ -49,12 +62,21 @@ def get_ray_trafo(reco_space, use_subset=False):
 
     Aops = []
 
+    if not os.path.exists(data_path):
+        raise IOError('Could not find files at {}, have you run '
+                      'adutils.load_data_from_nas()'.format(data_path))
+
     for turn in turns:
         print("Loading geometry for turn number {} out of {}".format(turn + 1, nTurns))
-        geomFile = os.path.join(filePath, (fileStart + 'Turn_' + str(turn) + '.geometry.p'))
+        geomFile = os.path.join(data_path, (fileStart + 'Turn_' + str(turn) + '.geometry.p'))
+
         # Load pickled geometry (small workaround of incompatibility between Python2/Python3 in pickle)
         with open(geomFile, 'rb') as f:
-            geom = pickle.load(f, encoding='latin1')
+            if PY3:
+                geom = pickle.load(f, encoding='latin1')
+            else:
+                geom = pickle.load(f)
+
         # X-ray transform
         Aops.append(odl.tomo.RayTransform(reco_space, geom, impl='astra_cuda'))
 
@@ -80,19 +102,17 @@ def get_data(A, use_subset=False):
     else:
         turns = range(nTurns)
 
+    if not os.path.exists(data_path):
+        raise IOError('Could not find files at {}, have you run '
+                      'adutils.load_data_from_nas()'.format(data_path))
+
     imagesTurn = []
     for turn in turns:
         print("Loading data for turn number {} out of {}".format(turn + 1, nTurns))
-        dataFile = os.path.join(filePath, (fileStart + 'Dose150mGy_Turn_' + str(turn) + '.data.npy'))
+        dataFile = os.path.join(data_path, (fileStart + 'Dose150mGy_Turn_' + str(turn) + '.data.npy'))
         projections = np.load(dataFile).astype('float32')
         imagesTurn.append(-np.log(projections / 7910))
 
     rhs = A.range.element(imagesTurn)
 
     return rhs
-
-
-
-
-
-


### PR DESCRIPTION
General style fixes and some usability:

* PEP8 fixes of code
* Added .gitignore, specifically to avoid .pyc files, but also for the data folder
* Changed behaviour to first copy data to local folder, signficantly improves run-time.
* Removed `getPhantomSize`, simply hardcoded the value instead.
* Changed `get_ray_trafo` to take `reco_space` as an input parameter, thus allowing users to change the discretization if they want.
* Changed default behaviour of the load functions to load full data instead of subset
* Fixed a Python 2 bug with pickle
* Removed all default save behavior by default.  See #1 for further suggestion.
* Renamed `discr_reco_space` to `reco_space`